### PR TITLE
override product_uuid with a random UUID on first time start up.

### DIFF
--- a/ubuntu14-osquery/Dockerfile
+++ b/ubuntu14-osquery/Dockerfile
@@ -2,9 +2,10 @@ FROM ubuntu:14.04
 MAINTAINER Zach Wasserman <zwass@kolide.co>
 
 # Get add-apt-repository
-RUN apt-get update \
-  && apt-get install -y software-properties-common \
-  && apt-get install apt-transport-https
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    apt-transport-https \
+    uuid-runtime
 
 # Add the apt repository for osquery packages
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B \
@@ -19,5 +20,8 @@ RUN rm -rf /var/lib/apt/lists/*
 # Copy the default osquery.conf (However, a custom conf should be specified
 # with `docker run -v osquery.conf:/etc/osquery.conf zwass/osqueryd`
 COPY osquery.example.conf /etc/osquery/osquery.conf
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["osqueryd", "--config_path=/etc/osquery/osquery.conf", "--verbose"]

--- a/ubuntu14-osquery/docker-entrypoint.sh
+++ b/ubuntu14-osquery/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!bin/sh
+# see https://github.com/facebook/osquery/issues/2819 for reference
+
+# FIXME note that product_uuid is in a read-only filesystem unless we explicitly
+# use a volume. Maybe check if the file is writable first? Or make the error silent.
+if [ ! -f /.osquery-uuidgen ]; then
+    uuidgen > /sys/class/dmi/id/product_uuid
+    touch /.osquery-uuidgen
+fi
+exec "$@"


### PR DESCRIPTION
See the `#FIXME` comment in the entrypoint.

We should also pin osquery to a version which would match the docker tag. I don't like how I get a new version of osqueryd every time I rebuild the container. 